### PR TITLE
fix: dry run report empty for files, assets, and missing-assets

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -683,10 +683,13 @@ async function handleFixes(result: ScanResult, config: Config, options: PrunyOpt
       targetRoutes = result.routes.filter(r => !r.used || (r.used && r.unusedMethods?.length > 0));
     }
 
-    const dryRunReport: { uniqueFiles: number; routes: unknown[]; exports: unknown[] } = {
+    const dryRunReport: { uniqueFiles: number; routes: unknown[]; exports: unknown[]; files: unknown[]; assets: unknown[]; missingAssets: unknown[] } = {
       uniqueFiles: new Set(targetRoutes.map(r => r.filePath)).size,
       routes: [],
-      exports: []
+      exports: [],
+      files: [],
+      assets: [],
+      missingAssets: []
     };
 
     if (selected === 'routes' || selected === 'dry-run-json' || action === 'dry-run') {
@@ -736,6 +739,33 @@ async function handleFixes(result: ScanResult, config: Config, options: PrunyOpt
         serviceClassName: m.serviceClassName
       }));
       dryRunReport.uniqueFiles = new Set(servicesList.map(m => m.file)).size;
+    }
+
+    if (selected === 'files') {
+      const filesList = result.unusedFiles?.files || [];
+      dryRunReport.files = filesList.map(f => ({
+        path: f.path,
+        size: f.size
+      }));
+      dryRunReport.uniqueFiles = filesList.length;
+    }
+
+    if (selected === 'assets') {
+      const assetsList = result.publicAssets?.assets.filter(a => !a.used) || [];
+      dryRunReport.assets = assetsList.map(a => ({
+        path: a.relativePath,
+        references: a.references
+      }));
+      dryRunReport.uniqueFiles = assetsList.length;
+    }
+
+    if (selected === 'missing-assets') {
+      const missingList = result.missingAssets?.assets || [];
+      dryRunReport.missingAssets = missingList.map(a => ({
+        path: a.path,
+        references: a.references
+      }));
+      dryRunReport.uniqueFiles = missingList.length;
     }
 
     const reportPath = join(process.cwd(), 'pruny-dry-run.json');


### PR DESCRIPTION
## Summary
- Dry run JSON report was empty (`uniqueFiles: 0`) when selecting "Unused Code Files", "Public Assets", or "Missing Assets"
- Root cause: the dry run handler only had `if` branches for `routes`, `exports`, and `services` — the other 3 categories were never handled
- Added handlers for `files`, `assets`, and `missing-assets` selections

Closes #12

## Changes
 src/index.ts | 34 ++++++++++++++++++++++++++++++++--
 1 file changed, 32 insertions(+), 2 deletions(-)

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | ✅ passed |
| typecheck | ✅ passed |
| test | ✅ passed (53/53) |
| build | ✅ passed |

## Test plan
- [ ] Create a Next.js project, add a dead file, run `npx pruny`, select "Unused Code Files", then "Dry Run" — verify JSON contains the file
- [ ] Verify dry run for unused public assets populates the `assets` array
- [ ] Verify dry run for missing assets populates the `missingAssets` array
- [ ] Verify existing dry run for routes/exports/services still works unchanged