### PR TITLE
fix(scanner): vercel.json monorepo lookup and dot-directory source scanning

### DIFF
--- a/src/scanner.ts
+++ b/src/scanner.ts
@@ -518,7 +518,8 @@ export async function scan(config: Config): Promise<ScanResult> {
   }
 
   // 3. Mark vercel external routes as used
-  const vercelPaths = getVercelExternalPaths(cwd);
+  const vercelDir = config.appSpecificScan ? config.appSpecificScan.appDir : cwd;
+  const vercelPaths = getVercelExternalPaths(vercelDir);
   for (const extPath of vercelPaths) {
     const route = routes.find((r) => r.path === extPath);
     if (route) {
@@ -551,6 +552,7 @@ export async function scan(config: Config): Promise<ScanResult> {
   const sourceFiles = await fg(extGlob, {
     cwd: referenceScanCwd,
     ignore: [...config.ignore.folders, ...config.ignore.files],
+    dot: true,
   });
 
   // 5. Collect all API references


### PR DESCRIPTION
## Summary
- **Bug 1**: `getVercelExternalPaths()` used `cwd` (monorepo root) to find `vercel.json`, but in monorepos it lives inside the app dir (e.g., `apps/web/vercel.json`). Now uses `appSpecificScan.appDir` when available — same pattern as `getAutoDetectedExternalRoutes()`.
- **Bug 2**: `fast-glob` excludes dot-directories by default, so `.well-known/` route files (containing template literal API references like `` `${BASE_URL}/api/oauth/token` ``) were never scanned. Added `dot: true` to include them (dangerous dot-dirs like `.next`, `.git` are already in the ignore list).

Fixes #20

## Changes
 src/scanner.ts | 4 +++-
 1 file changed, 3 insertions(+), 1 deletion(-)

## CI Pre-check
| Check | Status |
|-------|--------|
| lint | ✅ passed |
| typecheck | ✅ passed |
| test | ✅ passed (53/53) |
| build | ✅ passed |

## Test plan
- [x] Verified against `practice-stack` monorepo — all 6 cron routes + `/api/daily` auto-detected from `apps/web/vercel.json`
- [x] Verified `/api/oauth/token` and `/api/oauth/register` detected via `.well-known` template literal references
- [x] All 53 existing tests pass