### PR TITLE
chore(ci): add Claude Code workflows

### DIFF
--- a/.github/workflows/claude-auto-fix.yml
+++ b/.github/workflows/claude-auto-fix.yml
@@ -1,0 +1,80 @@
+name: Claude Auto-Fix Issues
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  auto-fix:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Bun & install
+        uses: WebNaresh/bun-setup-action@v1
+        with:
+          bun-version: '1.3.7'
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --permission-mode acceptEdits
+            --allowedTools "Bash,Edit,Write,Read,Glob,Grep,WebFetch"
+          prompt: |
+            Issue #${{ github.event.issue.number }} was just opened.
+
+            Title: ${{ github.event.issue.title }}
+            Author: ${{ github.event.issue.user.login }}
+            Assignees: ${{ join(github.event.issue.assignees.*.login, ',') }}
+
+            Body:
+            ${{ github.event.issue.body }}
+
+            STEP 1 — TRIAGE (mandatory, do this FIRST):
+            Decide whether this issue is a "simple bug fix" that you should auto-fix, or a "broader change" that needs human intervention. Err on the side of bailing out — if in doubt, do NOT open a PR.
+
+            Auto-fix ONLY if ALL of these are true:
+            - It is a clearly described bug with a reproducible symptom, a copy/text change, or a small CLI output tweak.
+            - The fix is confined to a small number of files and a localized code region.
+            - It requires NO changes to the core scanner engine (`src/scanner.ts`), the regex pattern library (`src/patterns.ts`), worker-thread orchestration (`src/scanners/unused-exports.ts`), the fixer/deletion engine (`src/fixer.ts`), or config loading (`src/config.ts`).
+            - It requires NO new scanner, NO new CLI command/flag, and NO new dependency (no changes to `package.json` dependencies).
+            - It requires NO changes to CI workflows (`.github/`), build/config files (`tsconfig.json`, `tsup.config.*`, `.releaserc*`), or the semantic-release pipeline.
+            - It does NOT touch more than ~5 files or ~150 lines total.
+            - The expected behavior is unambiguous from the issue body — no design decisions, no product judgment calls required.
+
+            DO NOT auto-fix (bail out) if ANY of these are true:
+            - Core scanner engine, pattern library, worker orchestration, or fixer logic changes are implied.
+            - It is a feature request (new scanner, new CLI flag, new output format), refactor, architectural change, or "broader" rework.
+            - It spans multiple scanners or requires cross-cutting changes.
+            - It touches file deletion/modification logic or anything security-sensitive (e.g. path handling, glob traversal).
+            - The issue is vague, ambiguous, lacks repro steps, or needs clarification.
+            - Fixing it safely would require human product/design judgment.
+
+            If you decide to bail out: post ONE comment on the issue explaining that this looks like a broader change needing human intervention, briefly state why (core-engine change / new scanner / ambiguous / etc.), and STOP. Do NOT create a branch, do NOT open a PR.
+
+            STEP 2 — FIX (only if triage passed):
+            1. Investigate the issue. Read relevant code and confirm the bug before making changes.
+            2. Create and switch to a new branch named `claude/issue-${{ github.event.issue.number }}` based on `main`.
+            3. Implement the fix. Follow existing code style and patterns (regex-based, ESM-only).
+            4. Add a regression test under `tests/` that reproduces the bug and passes after the fix.
+            5. Run `bun run validate` and `bun test` from the repo root. If anything fails, fix it before committing.
+            6. Commit each changed file individually using conventional commit format (e.g. `fix(scanner): ...`). Do NOT add any Co-Authored-By or Claude attribution lines.
+            7. Push the branch to origin.
+            8. Open a pull request targeting `main` using `gh pr create`. Include the line `Closes #${{ github.event.issue.number }}` in the PR body so GitHub auto-closes the issue when the PR merges. Pass `--assignee` with the issue's assignees (comma-separated). If the issue has no assignees, use the issue author `${{ github.event.issue.user.login }}` as the assignee.
+            9. Post a single comment on the issue linking to the new PR.
+            10. NEVER run `gh pr merge` — the repo owner handles merging.
+
+            If at any point during the fix you discover the change is broader than the triage suggested (e.g. you need a new scanner, core-engine changes, or design decisions), STOP, discard the branch, and post a comment on the issue explaining this needs human intervention.

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,57 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  claude:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      id-token: write
+      actions: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run Claude Code
+        id: claude
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          additional_permissions: |
+            actions: read
+          claude_args: |
+            --permission-mode acceptEdits
+            --allowedTools "Bash,Edit,Write,Read,Glob,Grep,WebFetch"
+          prompt: |
+            You were tagged via @claude on ${{ github.event_name }} in repo ${{ github.repository }}.
+
+            Follow the user's instructions in the triggering comment/issue/review.
+
+            If the task requires code changes on an issue (not already on a PR branch):
+            1. Create a branch named `claude/issue-${{ github.event.issue.number }}` (or a unique name if that exists).
+            2. Implement the fix following existing code style.
+            3. Commit each changed file individually using conventional commit format (e.g. `fix(scope): ...`). Never add Co-Authored-By or any Claude attribution.
+            4. Push the branch to origin.
+            5. Open a pull request to `main` using `gh pr create`. Put `Closes #${{ github.event.issue.number }}` in the PR body so the issue auto-closes on merge. Pass `--assignee` with the issue's assignees (comma-separated list from `${{ join(github.event.issue.assignees.*.login, ',') }}`). If that list is empty, use the issue author `${{ github.event.issue.user.login }}`.
+            6. Post a single comment on the issue linking to the PR.
+            7. NEVER run `gh pr merge` — the repo owner handles merging.
+
+            If the task is on an existing PR (review/comment), push commits to that PR's branch directly; do not open a new PR.


### PR DESCRIPTION
## Summary

Adds two GitHub Actions workflows mirroring the setup used in practice-stack and glitchgrab:

- **claude.yml** — runs when `@claude` is mentioned in issues, issue comments, PR review comments, or PR reviews. Follows the instruction, opens a branch + PR to `main`, and comments back. Never runs `gh pr merge`.
- **claude-auto-fix.yml** — fires on new issue creation. Runs a strict triage first and only auto-fixes clearly small, localized bugs. Bails out with a comment for anything touching the scanner engine, pattern library, worker orchestration, fixer logic, or requiring new scanners/flags/deps.

Triage rules adapted for pruny's stack (CLI scanner tool, regex-based, ESM-only) — carve-outs protect `src/scanner.ts`, `src/patterns.ts`, `src/scanners/unused-exports.ts`, `src/fixer.ts`, and `src/config.ts`.

The `CLAUDE_CODE_OAUTH_TOKEN` repo secret is already configured.

## Test plan
- [ ] Tag `@claude` in a test issue — verify workflow runs and responds
- [ ] Open a small-bug test issue — verify triage runs and either auto-fixes (with regression test) or bails out with explanation