### PR TITLE
fix(broken-links): detect template-literal links + filter gitignore negation patterns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,11 +38,32 @@ After fixing a bug or adding a feature, **always** build and run against these t
 
 ```bash
 bun run build
-node dist/index.js --dir /Users/webnaresh/coding-line/practice-stack/apps/web --all
-node dist/index.js --dir /Users/webnaresh/coding-line/abhyaiska --all
+node dist/index.js --dir /Users/webnaresh/coding-line/practice-stack --ignore-apps extension
+node dist/index.js --dir /Users/webnaresh/coding-line/abhyaiska
 ```
 
 Both must exit with 0 unused items (or only known/pre-existing issues). If either reports a new false positive, investigate before pushing.
+
+Skip `bun link` during iteration — `node dist/index.js --dir <project>` invokes the freshly built local scanner directly. No npm install / global link needed.
+
+### Testing broken-link scanner specifically
+
+To verify template-literal `${}` capture + gitignore-pattern handling after editing `src/scanners/broken-links.ts`, drop a scratch file into the target project and re-run:
+
+```tsx
+// <project>/app/__test_broken_links.tsx (gitignored dir optional, any depth works)
+import Link from "next/link";
+const id = "x";
+export const A = () => <Link href={`/does/not/exist/${id}`}>dead</Link>;
+export const B = () => <Link href="/nope">static dead</Link>;
+```
+
+A correct run prints both under **Broken Internal Links**. If nothing surfaces:
+- Check regex captured the template literal — run `DEBUG_PRUNY=1 node dist/index.js --dir <project>` and look for `[TRACE POST]` lines.
+- Check `isGitignoredPublicFile()` isn't flipping on negation patterns in `.gitignore` (lines starting with `!`). Those must be filtered out before feeding to minimatch — otherwise every unrelated path matches and broken detection silently no-ops.
+- Remember template literals are normalized via `normalizePath()` → every `${...}` collapses to `[id]` so they align with Next.js dynamic-route segments.
+
+Delete the scratch file after verifying.
 
 ## Architecture
 

--- a/src/scanners/broken-links.ts
+++ b/src/scanners/broken-links.ts
@@ -18,29 +18,33 @@ export interface BrokenLinksResult {
 
 /**
  * Regex patterns to extract internal route references from source files.
- * Each captures a path starting with / in group 1 (or group 2 for router patterns).
+ *
+ * Both plain string literals AND template literals are captured. For template
+ * literals (paths that embed `${...}`), `normalizePath` later replaces each
+ * expression with `[id]` so the value becomes a dynamic-route reference we
+ * can validate against Next.js's `app/.../[id]/page.tsx` layout.
  */
 const LINK_PATTERNS: RegExp[] = [
-  // <Link href="/path"> or <Link href='/path'>
-  /<Link\s+[^>]*href\s*=\s*['"`](\/[^'"`\s{}$]+)['"`]/g,
+  // <Link href="/path"> | <Link href='/path'> | <Link href={`/path/${id}`}>
+  /<Link\s+[^>]*href\s*=\s*(?:\{\s*)?['"`](\/[^'"`\s]+)['"`](?:\s*\})?/g,
 
-  // router.push("/path") / router.replace("/path")
-  /router\.(push|replace)\s*\(\s*['"`](\/[^'"`\s{}$]+)['"`]/g,
+  // router.push("/path") / router.replace("/path") / router.push(`/path/${id}`)
+  /router\.(push|replace)\s*\(\s*['"`](\/[^'"`\s]+)['"`]/g,
 
   // redirect("/path") / permanentRedirect("/path")
-  /(?:redirect|permanentRedirect)\s*\(\s*['"`](\/[^'"`\s{}$]+)['"`]/g,
+  /(?:redirect|permanentRedirect)\s*\(\s*['"`](\/[^'"`\s]+)['"`]/g,
 
   // href: "/path" (navigation config objects)
-  /href\s*:\s*['"`](\/[^'"`\s{}$]+)['"`]/g,
+  /href\s*:\s*['"`](\/[^'"`\s]+)['"`]/g,
 
   // <a href="/path"> (plain HTML)
-  /<a\s+[^>]*href\s*=\s*['"`](\/[^'"`\s{}$]+)['"`]/g,
+  /<a\s+[^>]*href\s*=\s*(?:\{\s*)?['"`](\/[^'"`\s]+)['"`](?:\s*\})?/g,
 
   // revalidatePath("/path")
-  /revalidatePath\s*\(\s*['"`](\/[^'"`\s{}$]+)['"`]/g,
+  /revalidatePath\s*\(\s*['"`](\/[^'"`\s]+)['"`]/g,
 
   // pathname === "/path" or pathname === '/path' (usePathname comparisons)
-  /pathname\s*===?\s*['"`](\/[^'"`\s{}$]+)['"`]/g,
+  /pathname\s*===?\s*['"`](\/[^'"`\s]+)['"`]/g,
 ];
 
 /**
@@ -52,6 +56,25 @@ function extractPath(match: RegExpExecArray): string | null {
   if (match[2] && match[2].startsWith('/')) return match[2];
   if (match[1] && match[1].startsWith('/')) return match[1];
   return null;
+}
+
+/**
+ * Normalize a captured path so template-literal placeholders become `[id]`
+ * segments that match Next.js dynamic route files. Anything inside `${...}` —
+ * including complex expressions or nested braces — collapses to `[id]`.
+ *
+ * Examples:
+ *   /dashboard/compliance/${id}                  -> /dashboard/compliance/[id]
+ *   /firm/${slug}/onboarding/${token}            -> /firm/[id]/onboarding/[id]
+ *   /foo/${ getId() }/bar                        -> /foo/[id]/bar
+ */
+function normalizePath(raw: string): string {
+  // Replace `${...}` with [id]. Non-greedy, single-level braces (enough for
+  // typical expressions; `${` nesting is rare in href interpolations).
+  let out = raw.replace(/\$\{[^}]*\}/g, '[id]');
+  // Drop any stray braces that survived (e.g. unmatched closing).
+  out = out.replace(/[{}]/g, '');
+  return out;
 }
 
 /**
@@ -236,7 +259,10 @@ function isGitignoredPublicFile(appDir: string, linkPath: string): boolean {
       const patterns = readFileSync(gitignorePath, 'utf-8')
         .split('\n')
         .map(l => l.trim())
-        .filter(l => l && !l.startsWith('#'));
+        // Drop comments, blanks AND negation re-includes (`!pattern`). minimatch
+        // treats `!foo` as "match anything NOT foo" which flips the match for
+        // every unrelated path and silently ignores broken-link detection.
+        .filter(l => l && !l.startsWith('#') && !l.startsWith('!'));
 
       for (const pattern of patterns) {
         if (minimatch(publicRelPath, pattern, { dot: true }) ||
@@ -347,8 +373,11 @@ export async function scanBrokenLinks(config: Config): Promise<BrokenLinksResult
         let match: RegExpExecArray | null;
 
         while ((match = pattern.exec(content)) !== null) {
-          const rawPath = extractPath(match);
-          if (!rawPath) continue;
+          const extracted = extractPath(match);
+          if (!extracted) continue;
+          // Collapse `${...}` placeholders into [id] so template literals can
+          // be matched against dynamic Next.js route segments.
+          const rawPath = normalizePath(extracted);
           if (shouldSkipPath(rawPath)) continue;
 
           const cleaned = cleanPath(rawPath);


### PR DESCRIPTION
## Summary
- Template-literal Link paths like ``\`/dashboard/compliance/${id}\``` were silently dropped by the link extractor regex (which excluded `{}$`). Now captured + normalized: every `${...}` collapses to `[id]` so dynamic links align with Next.js `[id]` route segments.
- `isGitignoredPublicFile()` was feeding `.gitignore` negation lines (`!.yarn/patches` etc.) to minimatch. minimatch interprets a leading `!` as "match anything NOT this", so every unrelated path matched → every broken link was silently suppressed. Negation patterns now filtered out before minimatch sees them.

## Impact
Tested on `practice-stack` — 3 previously hidden broken links surfaced:
- `/dashboard/departments/[id]/services` (departments/page.tsx:147)
- `/dashboard/proposals/[id]/edit` (businesses `_components/proposals-table.tsx:212`)
- `/dashboard/proposals/[id]/pdf` (same, line 226)

Also picks up literal paths with template-literal siblings in the same file. No change in behavior for static `<Link href="/path">` or `router.push("/path")` — patch is strictly additive for prior false-negatives.

## Notes on CLAUDE.md
- Documented the local-dist test loop (`node dist/index.js --dir <project>`) so contributors don't need `bun link` while iterating.
- Added a broken-links scanner debug recipe: scratch file + `DEBUG_PRUNY=1` tracing, with explicit pitfalls (template-literal capture, gitignore negation flipping minimatch).

## Test plan
- [x] Local: dropped scratch file with template-literal href + static href; both flagged.
- [x] Local: practice-stack smoke → 3 real bugs surfaced.
- [x] Local: abhyaiska smoke → 2 flagged (1 sitemap build artifact, 1 real `[id]/[id]` route — both legitimate).
- [ ] CI green.